### PR TITLE
PR: New functionality in format_number() and README-typos fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ of threads exceeds 12-16. To set the number of threads, use the following functi
 
 ``` cpp
 // C++
-librapid::setNumThreads(<num>); // Set threads to <num>. <num> must be positive integer
-librapid::getNumThreads();      // Get number of threads. If OpenMP was not found, returns 1
+librapid::setNumThreads(<num>); // Set threads to <num>. <num> must be  apositive integer.
+librapid::getNumThreads();      // Get the number of threads. If OpenMP was not found, it returns 1.
 ```
 
 ``` python
 # Python
-librapid.setNumThreads(<num>); # Set threads to <num>. <num> must be positive integer
-librapid.getNumThreads();      # Get number of threads. If OpenMP was not found, returns 1
+librapid.setNumThreads(<num>); # Set threads to <num>. <num> must be a positive integer.
+librapid.getNumThreads();      # Get the number of threads. If OpenMP was not found, it returns 1.
 ```
 
 The `CMakeLists.txt` file will attempt to find a Blas installation automatically, though it may fail if the files are
@@ -152,7 +152,7 @@ blas-dir
 ├── lib
 |   └── your-blas-lib.lib
 └── bin (Only on Windows)
-    └── your-blass-dll.dll
+    └── your-blas-dll.dll
 ```
 
 ### Recommended Setup for Optimal Performance
@@ -202,5 +202,5 @@ look similar to this (example is for Windows):
                 └── OpenBLASTargets.cmake
 ```
 
-With OpenBLAS setup in this way, LibRapid will automatically find and use it, whether you're in C++ or building from
+With OpenBLAS set up in this way, LibRapid will automatically find and use it, whether you're in C++ or building from
 source for Python. This will (most likely) also give the best performance for the library.

--- a/src/librapid/stringmethods/format_number.cpp
+++ b/src/librapid/stringmethods/format_number.cpp
@@ -2,18 +2,29 @@
 #include <librapid/autocast/custom_complex.hpp>
 #include <string>
 #include <sstream>
+#include <algorithm>
 
 namespace librapid {
-	std::string format_number(const double &val, bool floating) {
+	std::string format_number(const double &val, bool floating, bool international) {
 		std::stringstream stream;
 		stream.precision(10);
 
 		stream << val;
 
 		std::string str = stream.str();
-		if (floating && str.find_last_of('.') == std::string::npos)
-			str += ".";
 
-		return str;
+		switch (international) {
+			case true:
+				if (floating && str.find_last_of('.') == std::string::npos)
+					str += ".0";
+
+				return str;
+			case false:
+				if (floating && str.find_last_of('.') == std::string::npos)
+					str += ",0";
+				else
+					std::replace(str.begin(), str.end(), '.', ',');
+				return str;
+		}
 	}
 }

--- a/src/librapid/stringmethods/format_number.cpp
+++ b/src/librapid/stringmethods/format_number.cpp
@@ -17,14 +17,12 @@ namespace librapid {
 			case true:
 				if (floating && str.find_last_of('.') == std::string::npos)
 					str += ".0";
-
-				return str;
 			case false:
 				if (floating && str.find_last_of('.') == std::string::npos)
 					str += ",0";
 				else
 					std::replace(str.begin(), str.end(), '.', ',');
-				return str;
 		}
+		return str;
 	}
 }

--- a/src/librapid/stringmethods/format_number.hpp
+++ b/src/librapid/stringmethods/format_number.hpp
@@ -5,7 +5,7 @@
 #include <librapid/autocast/custom_complex.hpp>
 
 namespace librapid {
-	std::string format_number(const double &val, bool floating = true);
+	std::string format_number(const double &val, bool floating = true, bool international = true);
 }
 
 #endif // LIBRAPID_FORMAT_NUMBER


### PR DESCRIPTION
This Pull-Request contains an addition to the format_number method. This allows for more international and regional use.
I also changed the "." to a ".0" instead for more explicit formatting/printing of numbers.

I also fixed some typos and weird sentences in the README.