### PR TITLE
Added optimised nth-Fibonacci number generator.

### DIFF
--- a/src/librapid/math/core_math.cpp
+++ b/src/librapid/math/core_math.cpp
@@ -107,7 +107,7 @@ namespace librapid {
 		return (tmp > 0 ? 1 : -1) * (round(tmp, figs - 1) * pow10(n));
 	}
 
-	__uint128_t nth_fibonacci(__uint128_t n) {
+	__uint128_t nthFibonacci(__uint128_t n) {
 		if(n >= 187)
 		{ throw new std::overflow_error("Numbers above 186 are not allowed as argument."); }
 

--- a/src/librapid/math/core_math.cpp
+++ b/src/librapid/math/core_math.cpp
@@ -106,4 +106,21 @@ namespace librapid {
 
 		return (tmp > 0 ? 1 : -1) * (round(tmp, figs - 1) * pow10(n));
 	}
+
+	__uint128_t nth_fibonacci(__uint128_t n) {
+		if(n >= 187)
+		{ throw new std::overflow_error("Numbers above 186 are not allowed as argument."); }
+
+		if (n <= 75) // As the C++ standard only defines long double to be at least 2x the 
+					 // precision of a regular double, we check if that limit is exceeded or not.
+		{ return (__uint128_t) roundl(pow(0.5 * (1.0 + sqrt5), (long double) n)) / sqrt5; }
+
+		int a = 0, b = 1, c, i;
+		for (i = 2; i <= n; i++) {
+		    c = a + b;
+		    a = b;
+		    b = c;
+		}
+		return b;
+	}
 }

--- a/src/librapid/math/core_math.cpp
+++ b/src/librapid/math/core_math.cpp
@@ -107,13 +107,13 @@ namespace librapid {
 		return (tmp > 0 ? 1 : -1) * (round(tmp, figs - 1) * pow10(n));
 	}
 
-	__uint128_t nthFibonacci(__uint128_t n) {
-		if(n >= 187)
-		{ throw new std::overflow_error("Numbers above 186 are not allowed as argument."); }
+	uint64_t nthFibonacci(uint8_t n) {
+		if(n >= 100)
+		{ throw new std::overflow_error("Numbers above 100 are not allowed as argument."); }
 
 		if (n <= 75) // As the C++ standard only defines long double to be at least 2x the 
 					 // precision of a regular double, we check if that limit is exceeded or not.
-		{ return (__uint128_t) roundl(pow(0.5 * (1.0 + sqrt5), (long double) n)) / sqrt5; }
+		{ return (uint64_t) roundl(pow(0.5 * (1.0 + sqrt5), (long double) n)) / sqrt5; }
 
 		int a = 0, b = 1, c, i;
 		for (i = 2; i <= n; i++) {


### PR DESCRIPTION
If `n` is less than or equal to 75 (the precision limit of the double data type), we use the formula `(½(1 + √5))ⁿ / √5` to compute the `n`th number.

Note: As `long double` only needs to be *at least* as precise as the regular double, I set the limit to the particular number 75.