### PR TITLE
Update favicon extension name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,7 @@ extensions = [
     "breathe",
     "exhale",
     "numpydoc",
-    "sphinx-favicon",
+    "sphinx_favicon",
     "myst_parser",
     "sphinx_design",
     "sphinx_copybutton"


### PR DESCRIPTION
Thanks for using [Sphinx Favicon](https://github.com/tcmetzger/sphinx-favicon) in your project! I just released version 1.0 of the extension, which brings one breaking change: to better conform with Python standards, we changed the module name to `sphinx_favicon` (instead of `sphinx-favicon`). This means you'll have to update your conf.py file. This PR includes the necessary update - everything else should keep working like before!